### PR TITLE
Inspect Zsh dotfiles manually in the CI workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,3 +56,12 @@ jobs:
 
       - name: Check (zsh)
         run: ./macos/check
+
+      - name: 👁️ Inspect ~/.zshrc
+        run: cat ~/.zshrc
+
+      - name: 👁️ Inspect ~/.zshenv
+        run: cat ~/.zshenv
+
+      - name: 👁️ Inspect ~/.zprofile
+        run: cat ~/.zprofile

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,16 +30,6 @@ jobs:
         os:
           - macos-15  # The latest macOS running on Apple Silicon.
 
-    defaults:
-      run:
-        # Using zsh as the default shell instead of bash.
-        #
-        # Using -l (login) ensures that the shell starts as a login shell, which is
-        # important for loading the correct environment variables and configurations.
-        #
-        # Spec: <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell>
-        shell: /bin/zsh -l {0}
-
     steps:
       - name: Clean up pre-installed software
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,9 +49,12 @@ jobs:
 
       - name: 👁️ Inspect ~/.zshrc
         run: cat ~/.zshrc
+        continue-on-error: true
 
       - name: 👁️ Inspect ~/.zshenv
         run: cat ~/.zshenv
+        continue-on-error: true
 
       - name: 👁️ Inspect ~/.zprofile
         run: cat ~/.zprofile
+        continue-on-error: true


### PR DESCRIPTION
This pull-request extends the CI workflow for macOS such that the dotfiles relevant for Zsh are available for manual inspection via the execution logs.

Additionally, I've taken the opportunity to revert the default shell used in this workflow to its original value -- Bash.
