### PR TITLE
Inspect UI manually in the CI workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,3 +58,15 @@ jobs:
       - name: 👁️ Inspect ~/.zprofile
         run: cat ~/.zprofile
         continue-on-error: true
+
+      - name: Check user-interface
+        run: |
+          mkdir screenshots
+          ./macos/check-ui screenshots
+
+      - name: Upload user-interface screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: screenshots/*
+          if-no-files-found: error

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,15 +49,14 @@ jobs:
 
       - name: 👁️ Inspect ~/.zshrc
         run: cat ~/.zshrc
-        continue-on-error: true
+        continue-on-error: true  # TODO: fail-on-error when the file is populated by the bootstrap scripts.
 
       - name: 👁️ Inspect ~/.zshenv
         run: cat ~/.zshenv
-        continue-on-error: true
+        continue-on-error: true  # TODO: fail-on-error when the file is populated by the bootstrap scripts.
 
       - name: 👁️ Inspect ~/.zprofile
         run: cat ~/.zprofile
-        continue-on-error: true
 
       - name: Check user-interface
         run: |

--- a/macOS/check
+++ b/macOS/check
@@ -13,7 +13,7 @@
 #     correctly configured.
 
 # Enable strict mode for better error handling.
-setopt errexit nounset pipefail
+setopt ERREXIT NOUNSET PIPEFAIL
 
 
 # === HELPERS ===

--- a/macOS/check
+++ b/macOS/check
@@ -6,7 +6,7 @@
 # according to the user's preferences.
 #
 # Usage:
-#   $(dotfiles)/macOS/check.sh
+#   $(dotfiles)/macOS/check
 #
 # Note:
 #   - This script must be run using Zsh because it also checks that Zsh has been

--- a/macOS/check-ui
+++ b/macOS/check-ui
@@ -1,0 +1,60 @@
+#!/bin/zsh
+#
+# User Interface Configuration Check Script
+#
+# This script captures the screen at appropriate scenarios to manually check
+# that the macOS machine is ready for use and has been configured according to
+# the user's preferences.
+#
+# Usage:
+#   $(dotfiles)/macOS/check-ui SCREENSHOTS-DIRECTORY
+#
+# Note:
+#   - This script outputs the captured screens to a folder given by the user.
+#   - The given directory must exist and be writable, otherwise the script will
+#     fail early with an error.
+
+# Enable strict mode for better error handling.
+setopt ERREXIT NOUNSET PIPEFAIL
+
+
+# === HELPERS ===
+
+error() {
+  # Print message in red.
+  echo -e "\\033[1;31m[ERROR]\\033[0m $*" >&2
+  exit 1
+}
+
+info() {
+  # Print message in green.
+  echo -e "\\033[1;32m[INFO]\\033[0m  $*"
+}
+
+warn() {
+  # Print message in green.
+  echo -e "\\033[1;33m[WARN]\\033[0m  $*"
+}
+
+
+# === PARSE ARGUMENTS ===
+
+# Captured screenshots will be saved in this directory.
+if [[ $# -ne 1 || -z "$1" ]]; then
+  echo "USAGE: $(basename $0) SCREENSHOTS-DIRECTORY"
+  error "Please provide a directory to save the screenshots."
+fi
+output_dir="$1"
+
+# Create the output directory if it does not exist.
+if [[ ! -d "${output_dir}" ]]; then
+  error "The output directory does not exist: ${output_dir}"
+fi
+info "Captured screenshots will be saved in: ${output_dir}"
+
+
+# === CHECKS ===
+
+# Capture the initial Desktop screen.
+screencapture -x "${output_dir}/desktop.png"
+warn "✅ Check the Dock applications and the Desktop icons."

--- a/macOS/install.d/01-homebrew
+++ b/macOS/install.d/01-homebrew
@@ -6,7 +6,8 @@
 #
 # Terminology: <https://docs.brew.sh/Formula-Cookbook#homebrew-terminology>
 
-setopt errexit nounset pipefail  # Enable strict mode for better error handling
+# Enable strict mode for better error handling.
+setopt ERREXIT NOUNSET PIPEFAIL
 
 
 command_exists() {


### PR DESCRIPTION
This pull-request extends the CI workflow for macOS such that the runner's screen is captured and uploaded for manual inspection via the workflow run.

Additionally, I've taken the opportunity to fix some typos, no changes to the existing scripts otherwise.